### PR TITLE
Fixed block-breaking-particle duplication, fast-falling rain, and FOV transition bugs.

### DIFF
--- a/src/main/java/com/xcompwiz/lookingglass/client/proxyworld/ProxyWorldManager.java
+++ b/src/main/java/com/xcompwiz/lookingglass/client/proxyworld/ProxyWorldManager.java
@@ -119,6 +119,10 @@ public class ProxyWorldManager {
 		EntityLivingBase backup = mc.renderViewEntity;
 		mc.renderViewEntity = view.camera;
 		view.getRenderGlobal().setWorldAndLoadRenderers(proxyworld);
+		// The line of code below prevents block-breaking particles from duplicating
+		// when a WorldView exists in the same dimension as the player. I've haven't
+		// noticed any unwanted results from using this yet.
+		if(proxyworld.provider.dimensionId == Minecraft.getMinecraft().thePlayer.dimension) proxyworld.removeWorldAccess(view.getRenderGlobal());
 		mc.renderViewEntity = backup;
 
 		// Inform the server of the new view

--- a/src/main/java/com/xcompwiz/lookingglass/client/render/RenderUtils.java
+++ b/src/main/java/com/xcompwiz/lookingglass/client/render/RenderUtils.java
@@ -50,8 +50,8 @@ public class RenderUtils {
 			EXTFramebufferObject.glBindFramebufferEXT(EXTFramebufferObject.GL_FRAMEBUFFER_EXT, framebuffer);
 			GL11.glClearColor(1.0f, 0.0f, 0.0f, 0.5f);
 			GL11.glClear(GL11.GL_COLOR_BUFFER_BIT);
-
-			entityRenderer.updateRenderer();
+			
+			//entityRenderer.updateRenderer();
 
 			int i1 = mc.gameSettings.limitFramerate;
 			if (mc.isFramerateLimitBelowMax()) {

--- a/src/main/java/com/xcompwiz/lookingglass/render/WorldViewRenderManager.java
+++ b/src/main/java/com/xcompwiz/lookingglass/render/WorldViewRenderManager.java
@@ -54,7 +54,10 @@ public class WorldViewRenderManager {
 					activeview.camera.inventory.mainInventory[playerBackup.inventory.currentItem] = currentClientItem; //Prevents the hand from flickering
 
 					try {
-						mc.entityRenderer.updateRenderer();
+						// TODO: A "fast-falling rain" bug occurs when the two updateRenderer() calls in WorldViewRenderManager
+						// and one in RenderUtils aren't commented out. There doesn't seem to be any issues with not
+						// calling them (everything still looks to render properly), so this is a quick fix for the time being.
+						//mc.entityRenderer.updateRenderer();
 						mc.renderGlobal.updateClouds();
 						mc.theWorld.doVoidFogParticles(MathHelper.floor_double(activeview.camera.posX), MathHelper.floor_double(activeview.camera.posY), MathHelper.floor_double(activeview.camera.posZ));
 						mc.effectRenderer.updateEffects();
@@ -78,7 +81,7 @@ public class WorldViewRenderManager {
 		mc.renderGlobal = renderBackup;
 		mc.theWorld = worldBackup;
 		RenderManager.instance.set(mc.theWorld);
-		mc.entityRenderer.updateRenderer();
+		//mc.entityRenderer.updateRenderer();
 	}
 
 }


### PR DESCRIPTION
This pull request fixes a block-breaking-particle duplication bug when a WorldView is present in the same dimension as the player. From what it looked like, the more WorldViews you had, the more particles came out of a block when you broke it. This also fixes a "fast-falling rain" bug that also occurs for the same reason. I commented out three EntityRenderer.updateRenderer() calls to fix it. There doesn't seem to be any bad side-effects from doing that (entities, blocks, items, they all still render properly.)
